### PR TITLE
Fix the "Run the script" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To utilize this tool, ensure the installation of:
 ## Usage Guide
 
 Run the script:
-    ```bash
-    python main.py -i input_video.mp4 -o output_video.mp4
-    ```
+```bash
+python main.py -i input_video.mp4 -o output_video.mp4
+```
 
 The script processes the input video and generates an output with the densePose format.
 


### PR DESCRIPTION
Hello,

There is an issue with the `Run the script` example in the [Usage Guide](https://github.com/Flode-Labs/vid2densepose#usage-guide).
An excessive indentation leads to a wrongly rendered misleading code.

Best regards!